### PR TITLE
fix(ci): unblock the GPU release gate for cross-backend parity tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Run Torch and gradient contracts without skips
         run: |
           python -m pytest tests/test_torch_call_sites.py tests/test_gradient_contract.py \
-            -k torch --junitxml=torch-cuda.xml -q
+            -k torch -m "not cross_framework" --junitxml=torch-cuda.xml -q
           python scripts/assert_junit_no_skips.py torch-cuda.xml
 
   jax-cuda:
@@ -268,8 +268,51 @@ jobs:
       - name: Run JAX and gradient contracts without skips
         run: |
           python -m pytest tests/test_jax_call_sites.py tests/test_gradient_contract.py \
-            -k jax --junitxml=jax-cuda.xml -q
+            -k jax -m "not cross_framework" --junitxml=jax-cuda.xml -q
           python scripts/assert_junit_no_skips.py jax-cuda.xml
+
+  # Tests marked `cross_framework` need two backends resident at once, so no
+  # single-backend axis can run them: torch-cuda has no JAX and jax-cuda has no
+  # Torch, and each axis asserts zero skips. Before this job they were selected
+  # by both axes and skipped in both, which failed the no-skips gate and so kept
+  # gpu-axes-passed -- and with it the release gate -- permanently unreachable,
+  # while the assertions themselves never actually ran anywhere.
+  #
+  # Hosted CPU is sufficient: these compare gradients between backends, not
+  # device behaviour. Deliberately NOT part of gpu-axes-passed, which gates the
+  # release on CUDA correctness and must not start depending on a CPU job.
+  cross-framework-parity:
+    name: cross-framework-parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install both backends
+        run: python -m pip install -e ".[dev,pytorch,jax-cpu]"
+
+      - name: Assert both backends are importable
+        env:
+          JAX_PLATFORMS: cpu
+        run: |
+          python - <<'PY'
+          import jax, torch
+          print("torch", torch.__version__, "| jax", jax.__version__, jax.devices())
+          PY
+
+      - name: Run cross-backend parity tests without skips
+        env:
+          JAX_PLATFORMS: cpu
+        run: |
+          python -m pytest tests -m cross_framework \
+            --junitxml=cross-framework.xml -q
+          python scripts/assert_junit_no_skips.py cross-framework.xml
 
   # OpenCV, scikit-learn and PyBullet are in no hosted job's install, so 13
   # tests that need the real libraries skip everywhere and contribute nothing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,6 +306,7 @@ markers = [
     "parametrize: marks parametrized tests",
     "functional: marks functional tests",
     "tpu: marks fail-closed tests requiring a real Google Cloud TPU",
+    "cross_framework: marks tests needing two backends installed at once (e.g. Torch and JAX together). Single-backend CI axes must deselect these with -m 'not cross_framework' or they skip and fail the no-skips gate; the cross-framework-parity job runs them.",
 ]
 
 filterwarnings = [

--- a/tests/test_gradient_contract.py
+++ b/tests/test_gradient_contract.py
@@ -1218,6 +1218,7 @@ class TestJaxProductionGradientContract:
 
         assert np.all(np.isfinite(actual)), f"non-finite gradient at pi - {gap}"
 
+    @pytest.mark.cross_framework
     @pytest.mark.parametrize("theta_val", [0.0, 5e-7, 1e-6, 0.01, 0.1, 0.1001, 1.5])
     def test_matrix_log6_translational_gradient_matches_torch(self, theta_val):
         """Torch reaches the same translational gradient as JAX.


### PR DESCRIPTION
Closes #88.

## What

Adds a `cross_framework` pytest marker, applies it to the Torch/JAX gradient parity test, deselects that marker from the `torch-cuda` and `jax-cuda` axes, and adds a hosted `cross-framework-parity` job that installs both backends and runs exactly those tests.

## Why

`test_matrix_log6_translational_gradient_matches_torch` (7 parametrised cases) needs **Torch and JAX resident at the same time** — it differentiates the same dispatch under both and asserts the gradients agree. No job in `test.yml` installed both.

Both GPU axes selected it, and neither could run it:

- `jax-cuda` filters on `-k jax`, which matches the enclosing `TestJaxProductionGradientContract` class → skips on missing Torch.
- `torch-cuda` filters on `-k torch`, which matches the *test name* (`..._matches_torch`) → skips on missing JAX.

Both axes assert zero skips, so **both failed**. `gpu-axes-passed` requires all three CUDA axes and `gpu-release-gate` requires `gpu-axes-passed` for the released commit — so the release gate was unreachable and **no release could be published through the intended path**. Meanwhile the assertions never ran anywhere, leaving the Torch-side regression they exist to catch unguarded.

This was only visible once the axes were executed by hand on local GPU hardware. The GPU jobs gate on `GPU_RUNNER_ENABLED`, which is `false`, so they had never run.

## Why a marker instead of a `-k` filter

Name-based selection is exactly what coupled a JAX test to the Torch axis in the first place. A future cross-backend test whose name lacked the magic substring would silently reintroduce this. The marker states the requirement explicitly, and the repo's existing `--strict-markers` turns a typo into a hard error rather than a silent miss.

The new job runs on **hosted CPU** and is deliberately **not** part of `gpu-axes-passed` — it compares gradients between backends, not device behaviour, and that marker must keep gating the release on CUDA correctness alone. This mirrors the reasoning already documented for `optional-deps`.

## Verification

Each axis was reproduced in an environment matching what CI installs, running the real `scripts/assert_junit_no_skips.py` gate:

| Axis | Environment | Result |
|---|---|---|
| `jax-cuda` | `jax[cuda12]`, no Torch | **158 passed, 0 skipped** — gate passes |
| `torch-cuda` | `-k torch -m "not cross_framework"` | **62 passed, 0 skipped**; 0 JAX-class tests remain selected — gate passes |
| `cross-framework-parity` | both backends | **7 passed, 0 skipped in 5.0s** on CPU — gate passes |

Before this change, the identical `jax-cuda` command gave `158 passed, 7 skipped` and the gate failed — reproduced on an RTX 3060.

Also confirmed: the marker resolves under `--strict-markers` and selects exactly the 7 intended cases; the workflow YAML parses; `gpu-axes-passed` still needs only `cupy-gpu`, `torch-cuda`, `jax-cuda`.

`cupy-gpu` is untouched and independently verified passing on the same hardware (11 + 6 + 62 tests, zero skips).

## Note on ordering

Branched off `main`, not off #85, so the two are independent and can merge in either order. #85 (the 1.4.1 numba pin) is what gets released; this PR is what lets that release actually pass its gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added dedicated cross-framework parity testing across CPU-based Torch and JAX backends.
  - Ensured gradient translation comparisons run together and verify consistent results.
  - Added checks to detect skipped parity tests.
  - Updated test categorization for scenarios requiring multiple frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->